### PR TITLE
Removed mautic segment module from core config and database

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -33,8 +33,8 @@ module:
   jsonapi_include: 0
   link: 0
   mautic: 0
+  mautic_contacts: 0
   mautic_paragraph: 0
-  mautic_segment: 0
   media: 0
   media_library: 0
   menu_link_content: 0


### PR DESCRIPTION
This **PR #13** includes a small change to the `config/sync/core.extension.yml` file. The change involves updating the module configuration by adding `mautic_contacts` and removing `mautic_segment` from the list of modules.

* [`config/sync/core.extension.yml`](diffhunk://#diff-c74373ec0d30209248deac631a2a6db007924814cb51f9a620a807fbcb30de1dR36-L37): Added `mautic_contacts` and removed `mautic_segment` from the module list.