### PR TITLE
Mapping Mautic segments to the taxonomy terms dynamically

### DIFF
--- a/web/modules/custom/mautic_contacts/config/install/mautic_contacts.settings.yml
+++ b/web/modules/custom/mautic_contacts/config/install/mautic_contacts.settings.yml
@@ -1,0 +1,1 @@
+segment_taxonomy_mapping: {}

--- a/web/modules/custom/mautic_contacts/mautic_contacts.routing.yml
+++ b/web/modules/custom/mautic_contacts/mautic_contacts.routing.yml
@@ -39,3 +39,54 @@ mautic_contacts.segments:
       allowedMethods: ['GET']
       allowedOrigins: ['*']
       maxAge: 1000
+
+mautic_contacts.fetch_store_segments:
+  path: '/api/mautic-contacts/segments'
+  defaults:
+    _controller: '\Drupal\mautic_contacts\Controller\MauticContactsController::fetchAndStoreSegments'
+    _title: 'Fetch and Store Segments'
+  methods: [GET]
+  requirements:
+    _permission: 'access content'
+  options:
+    no_cache: TRUE
+    _cors:
+      enabled: TRUE
+      allowedHeaders: ['Content-Type']
+      allowedMethods: ['GET']
+      allowedOrigins: ['*']
+      maxAge: 1000
+
+mautic_contacts.map_segments:
+  path: '/api/mautic-contacts/map-segments'
+  defaults:
+    _controller: '\Drupal\mautic_contacts\Controller\MauticContactsController::mapSegmentsToTaxonomy'
+    _title: 'Map Segments to Taxonomy'
+  methods: [GET]
+  requirements:
+    _permission: 'administer taxonomy'
+  options:
+    no_cache: TRUE
+    _cors:
+      enabled: TRUE
+      allowedHeaders: ['Content-Type']
+      allowedMethods: ['GET']
+      allowedOrigins: ['*']
+      maxAge: 1000
+
+mautic_contacts.get_mapping:
+  path: '/api/mautic-contacts/mapping'
+  defaults:
+    _controller: '\Drupal\mautic_contacts\Controller\MauticContactsController::getMapping'
+    _title: 'Get Segment to Taxonomy Mapping'
+  methods: [GET]
+  requirements:
+    _permission: 'administer taxonomy'
+  options:
+    no_cache: TRUE
+    _cors:
+      enabled: TRUE
+      allowedHeaders: ['Content-Type']
+      allowedMethods: ['GET']
+      allowedOrigins: ['*']
+      maxAge: 1000

--- a/web/modules/custom/mautic_contacts/src/Service/MauticContactsApiClient.php
+++ b/web/modules/custom/mautic_contacts/src/Service/MauticContactsApiClient.php
@@ -140,4 +140,51 @@ class MauticContactsApiClient {
     }
   }
 
+  /**
+   * Gets all segments from Mautic API.
+   *
+   * @return array
+   *   An array of segments or empty array if request fails.
+   */
+  public function getSegments(): array {
+    try {
+      $config = $this->configFactory->get('mautic.settings');
+      
+      $url = $config->get('url') . '/api/segments';
+      $this->logger->debug('Attempting to fetch Mautic segments from: @url', ['@url' => $url]);
+      
+      $auth = [
+        $config->get('username'),
+        $config->get('password'),
+      ];
+      
+      $this->logger->debug('Using configured auth credentials');
+
+      $response = $this->httpClient->request('GET', $url, [
+        'auth' => $auth,
+        'headers' => [
+          'Accept' => 'application/json',
+        ],
+      ]);
+
+      $data = json_decode($response->getBody()->getContents(), TRUE);
+      $this->logger->debug('API Response status: @status', ['@status' => $response->getStatusCode()]);
+      $this->logger->debug('Segments data: @data', ['@data' => json_encode($data)]);
+
+      // Extract the segments from the nested structure
+      if (isset($data['lists'])) {
+        $data = $data['lists'];
+      }
+
+      return $data;
+    }
+    catch (GuzzleException $e) {
+      $this->logger->error('Failed to fetch Mautic segments: @error', [
+        '@error' => $e->getMessage(),
+        'trace' => $e->getTraceAsString()
+      ]);
+      return [];
+    }
+  }
+
 }


### PR DESCRIPTION
### [DWP-86](https://quanvuong.atlassian.net/browse/DWP-86)

This PR #14 introduces significant enhancements to the `mautic_contacts` module, focusing on integrating Mautic segments with Drupal taxonomy terms. The changes include new routes, controller methods, and API client methods to fetch, store, and map segments. Below are the most important changes:

### New Routes and Endpoints:

* Added new API endpoints to fetch and store segments, map segments to taxonomy terms, and retrieve the segment-to-taxonomy mapping. (`web/modules/custom/mautic_contacts/mautic_contacts.routing.yml`)

### Controller Enhancements:

* Implemented `fetchAndStoreSegments` method to retrieve segments from the Mautic API and store them in a shared tempstore. (`web/modules/custom/mautic_contacts/src/Controller/MauticContactsController.php`)
* Added `mapSegmentsToTaxonomy` method to map Mautic segments to Drupal taxonomy terms, creating new terms if necessary. (`web/modules/custom/mautic_contacts/src/Controller/MauticContactsController.php`)
* Introduced `getMapping` method to retrieve the stored segment-to-taxonomy mapping. (`web/modules/custom/mautic_contacts/src/Controller/MauticContactsController.php`)

### API Client Enhancements:

* Added `getSegments` method to the `MauticContactsApiClient` service to fetch all segments from the Mautic API, handling authentication and response parsing. (`web/modules/custom/mautic_contacts/src/Service/MauticContactsApiClient.php`)

### Configuration Changes:

* Introduced a new configuration setting `segment_taxonomy_mapping` to store the mapping of Mautic segments to Drupal taxonomy terms. (`web/modules/custom/mautic_contacts/config/install/mautic_contacts.settings.yml`)