### PR TITLE
Config: Exported the configuration

### DIFF
--- a/config/sync/asset_injector.js.mautic_script.yml
+++ b/config/sync/asset_injector.js.mautic_script.yml
@@ -6,11 +6,11 @@ id: mautic_script
 label: 'Mautic Script'
 code: |-
   (function(w,d,t,u,n,a,m){w['MauticTrackingObject']=n;
-          w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
-          m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://druid-mautic.lndo.site/mtc.js','mt');
+      w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
+      m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://mautic-lando.lndo.site/mtc.js','mt');
 
-      mt('send', 'pageview');
+  mt('send', 'pageview');
 noscript: ''
 noscriptRegion: {  }
 jquery: false

--- a/config/sync/core.entity_form_display.paragraph.card.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.card.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.paragraph.card.field_card_description
     - field.field.paragraph.card.field_card_image
     - field.field.paragraph.card.field_card_title
+    - field.field.paragraph.card.field_visible_to
     - paragraphs.paragraphs_type.card
   module:
     - link
@@ -46,6 +47,12 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_visible_to:
+    type: options_select
+    weight: 4
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.entity_form_display.paragraph.mautic.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.mautic.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.paragraph.mautic.field_mautic_title
     - paragraphs.paragraphs_type.mautic
   module:
-    - mautic_paragraph
     - text
 _core:
   default_config_hash: 9yBquGOPab9SGAQhPu-LRTcAdkg38E1vGgWkQyZwxiY
@@ -19,33 +18,33 @@ bundle: mautic
 mode: default
 content:
   field_mautic_formid:
-    weight: 2
-    settings: {  }
-    third_party_settings: {  }
-    type: autocomplete_mautic
-    region: content
-  field_mautic_layout:
-    weight: 3
-    settings: {  }
-    third_party_settings: {  }
     type: options_buttons
+    weight: 2
     region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_mautic_layout:
+    type: options_buttons
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_mautic_text:
+    type: text_textarea
     weight: 1
+    region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: text_textarea
-    region: content
   field_mautic_title:
+    type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   unomi_segment_section:
     type: options_select
     weight: 99

--- a/config/sync/core.entity_form_display.paragraph.mautic_form_embed.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.mautic_form_embed.default.yml
@@ -1,0 +1,23 @@
+uuid: 30c7fb91-3cc6-417c-9891-554beacb1854
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.mautic_form_embed.field_form_id
+    - paragraphs.paragraphs_type.mautic_form_embed
+id: paragraph.mautic_form_embed.default
+targetEntityType: paragraph
+bundle: mautic_form_embed
+mode: default
+content:
+  field_form_id:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_view_display.paragraph.card.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.card.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.paragraph.card.field_card_description
     - field.field.paragraph.card.field_card_image
     - field.field.paragraph.card.field_card_title
+    - field.field.paragraph.card.field_visible_to
     - paragraphs.paragraphs_type.card
   module:
     - link
@@ -50,5 +51,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_visible_to:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 5
     region: content
 hidden: {  }

--- a/config/sync/core.entity_view_display.paragraph.card.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.card.preview.yml
@@ -1,0 +1,30 @@
+uuid: 5662fc01-7337-4797-ba80-79e0305688e9
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.card.field_card_cta_button
+    - field.field.paragraph.card.field_card_description
+    - field.field.paragraph.card.field_card_image
+    - field.field.paragraph.card.field_card_title
+    - field.field.paragraph.card.field_visible_to
+    - paragraphs.paragraphs_type.card
+id: paragraph.card.preview
+targetEntityType: paragraph
+bundle: card
+mode: preview
+content:
+  field_visible_to:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+hidden:
+  field_card_cta_button: true
+  field_card_description: true
+  field_card_image: true
+  field_card_title: true

--- a/config/sync/core.entity_view_display.paragraph.hero_section.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.hero_section.default.yml
@@ -6,8 +6,8 @@ dependencies:
     - field.field.paragraph.hero_section.field_background_image
     - field.field.paragraph.hero_section.field_cta_button
     - field.field.paragraph.hero_section.field_description
-    - field.field.paragraph.hero_section.field_mautic_segment_visibility
     - field.field.paragraph.hero_section.field_titile
+    - field.field.paragraph.hero_section.field_visible_to
     - paragraphs.paragraphs_type.hero_section
   module:
     - link
@@ -44,14 +44,6 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
-  field_mautic_segment_visibility:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 5
-    region: content
   field_titile:
     type: string
     label: above
@@ -59,5 +51,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_visible_to:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 5
     region: content
 hidden: {  }

--- a/config/sync/core.entity_view_display.paragraph.hero_section.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.hero_section.preview.yml
@@ -1,8 +1,9 @@
-uuid: 8c6665f5-238d-4d28-a454-f45ad49aa8b5
+uuid: e2df918a-1c4e-4f9f-bf77-505eb11a5df8
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.paragraph.preview
     - field.field.paragraph.hero_section.field_background_image
     - field.field.paragraph.hero_section.field_cta_button
     - field.field.paragraph.hero_section.field_description
@@ -11,49 +12,53 @@ dependencies:
     - paragraphs.paragraphs_type.hero_section
   module:
     - link
-    - media_library
-id: paragraph.hero_section.default
+id: paragraph.hero_section.preview
 targetEntityType: paragraph
 bundle: hero_section
-mode: default
+mode: preview
 content:
   field_background_image:
-    type: media_library_widget
-    weight: 1
-    region: content
+    type: entity_reference_entity_view
+    label: above
     settings:
-      media_types: {  }
+      view_mode: default
+      link: false
     third_party_settings: {  }
-  field_cta_button:
-    type: link_default
-    weight: 3
-    region: content
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
-    third_party_settings: {  }
-  field_description:
-    type: string_textarea
     weight: 2
     region: content
+  field_cta_button:
+    type: link
+    label: above
     settings:
-      rows: 5
-      placeholder: ''
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
     third_party_settings: {  }
-  field_titile:
-    type: string_textfield
-    weight: 0
+    weight: 3
     region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_visible_to:
-    type: options_select
-    weight: 4
-    region: content
+  field_description:
+    type: basic_string
+    label: above
     settings: {  }
     third_party_settings: {  }
-hidden:
-  created: true
-  status: true
+    weight: 4
+    region: content
+  field_titile:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_visible_to:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.paragraph.mautic.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.mautic.default.yml
@@ -19,26 +19,26 @@ bundle: mautic
 mode: default
 content:
   field_mautic_formid:
-    weight: 2
+    type: mautic_form_list
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: mautic_form_list
+    weight: 2
     region: content
   field_mautic_text:
     type: text_default
-    weight: 1
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 1
+    region: content
   field_mautic_title:
-    weight: 0
+    type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 0
     region: content
 hidden:
   field_mautic_layout: true

--- a/config/sync/core.entity_view_display.paragraph.mautic_form_embed.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.mautic_form_embed.default.yml
@@ -1,0 +1,21 @@
+uuid: 099938c8-ef98-4678-a041-195542bbd46d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.mautic_form_embed.field_form_id
+    - paragraphs.paragraphs_type.mautic_form_embed
+id: paragraph.mautic_form_embed.default
+targetEntityType: paragraph
+bundle: mautic_form_embed
+mode: default
+content:
+  field_form_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/config/sync/field.field.paragraph.card.field_visible_to.yml
+++ b/config/sync/field.field.paragraph.card.field_visible_to.yml
@@ -1,0 +1,29 @@
+uuid: efc20f0b-f5f4-4f84-a88b-844d57642abf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_visible_to
+    - paragraphs.paragraphs_type.card
+    - taxonomy.vocabulary.mautic_segments
+id: paragraph.card.field_visible_to
+field_name: field_visible_to
+entity_type: paragraph
+bundle: card
+label: 'Visible to'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      mautic_segments: mautic_segments
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.paragraph.hero_section.field_visible_to.yml
+++ b/config/sync/field.field.paragraph.hero_section.field_visible_to.yml
@@ -1,24 +1,20 @@
-uuid: fc67b2d8-1fcf-4160-b2d4-ec4d3a5b2f1f
+uuid: 370c6ebc-6c38-4a70-9a55-e27a18aa49bc
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.paragraph.field_mautic_segment_visibility
+    - field.storage.paragraph.field_visible_to
     - paragraphs.paragraphs_type.hero_section
     - taxonomy.vocabulary.mautic_segments
-  content:
-    - 'taxonomy_term:mautic_segments:8b097e9a-5ff3-4cc1-9197-2a2688a2b792'
-id: paragraph.hero_section.field_mautic_segment_visibility
-field_name: field_mautic_segment_visibility
+id: paragraph.hero_section.field_visible_to
+field_name: field_visible_to
 entity_type: paragraph
 bundle: hero_section
-label: 'Mautic Segment Visibility'
+label: 'Visible to'
 description: ''
 required: false
 translatable: false
-default_value:
-  -
-    target_uuid: 8b097e9a-5ff3-4cc1-9197-2a2688a2b792
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/sync/field.field.paragraph.mautic_form_embed.field_form_id.yml
+++ b/config/sync/field.field.paragraph.mautic_form_embed.field_form_id.yml
@@ -1,0 +1,19 @@
+uuid: 831682fb-2bee-4cfd-bea4-7a31358f9687
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_form_id
+    - paragraphs.paragraphs_type.mautic_form_embed
+id: paragraph.mautic_form_embed.field_form_id
+field_name: field_form_id
+entity_type: paragraph
+bundle: mautic_form_embed
+label: 'Form ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.paragraph.field_form_id.yml
+++ b/config/sync/field.storage.paragraph.field_form_id.yml
@@ -1,0 +1,21 @@
+uuid: 5994c8c2-6f5b-41ec-8645-d630089232d3
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_form_id
+field_name: field_form_id
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_visible_to.yml
+++ b/config/sync/field.storage.paragraph.field_visible_to.yml
@@ -1,19 +1,19 @@
-uuid: 0e0c85e8-693f-4790-a2ff-6e3e68556773
+uuid: a348743d-f6ea-4120-a7b2-27c1229a3328
 langcode: en
 status: true
 dependencies:
   module:
     - paragraphs
     - taxonomy
-id: paragraph.field_mautic_segment_visibility
-field_name: field_mautic_segment_visibility
+id: paragraph.field_visible_to
+field_name: field_visible_to
 entity_type: paragraph
 type: entity_reference
 settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/mautic.settings.yml
+++ b/config/sync/mautic.settings.yml
@@ -2,11 +2,8 @@ _core:
   default_config_hash: 57YHD-gK9YrCd4mfkPt3DuRirKm_ZMRh2ILuF6JpC44
 visibility:
   request_path_mode: 0
-  request_path_pages: |-
-    /admin
-    /admin/*
-    /batch
-    /node/add*
-    /node/*/*
-    /user/*/*
+  request_path_pages: "/admin\r\n/admin/*\r\n/batch\r\n/node/add*\r\n/node/*/*\r\n/user/*/*"
 header: false
+lift_enable: null
+mautic_enable: true
+mautic_base_url: 'https://mautic-lando.lndo.site/mt.js'

--- a/config/sync/mautic_contacts.settings.yml
+++ b/config/sync/mautic_contacts.settings.yml
@@ -1,0 +1,4 @@
+segment_taxonomy_mapping:
+  'Test segment': '3'
+  users: '2'
+  visitor: '1'

--- a/config/sync/mautic_paragraph.settings.yml
+++ b/config/sync/mautic_paragraph.settings.yml
@@ -4,7 +4,7 @@ connector: basic_auth
 limit: 100
 connector_config:
   scheme: http
-  base_url: druid-mautic.lndo.site
+  base_url: mautic-lando.lndo.site
   port: ''
   path: ''
   username: hbc_druid

--- a/config/sync/paragraphs.paragraphs_type.mautic_form_embed.yml
+++ b/config/sync/paragraphs.paragraphs_type.mautic_form_embed.yml
@@ -1,0 +1,10 @@
+uuid: 63ca5c69-1c7b-4cae-ad7c-94cb94154f56
+langcode: en
+status: true
+dependencies: {  }
+id: mautic_form_embed
+label: 'Mautic Form Embed'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }


### PR DESCRIPTION
This PR #15 includes various updates and additions to configuration files, primarily focusing on renaming fields, updating URLs, and adding new configurations for paragraphs. The most important changes are categorized and summarized below:

### URL Updates:
* Updated the Mautic script URL in `config/sync/asset_injector.js.mautic_script.yml` to `https://mautic-lando.lndo.site/mtc.js`.
* Changed the base URL in `config/sync/mautic_paragraph.settings.yml` to `mautic-lando.lndo.site`.

### Field Renaming and Configuration:
* Renamed `field_mautic_segment_visibility` to `field_visible_to` and updated its configurations in multiple files including `config/sync/core.entity_form_display.paragraph.hero_section.default.yml` and `config/sync/field.storage.paragraph.field_visible_to.yml`. [[1]](diffhunk://#diff-785bddf202a4dfba1695ca23f8c64f5fbc61715eeef6ebd4f60a1a5d514022bcL9-R10) [[2]](diffhunk://#diff-d70a91316dd5321b3938f7b3f6ad3487e234c14b870abb1acdb5ac7f2098d2c1L1-R17) [[3]](diffhunk://#diff-7a940413fb7b2bc86103acce983602c8fce8a7e0fea1f06535d4c21df626cf19L1-R16)
* Added `field_visible_to` to the card paragraph type in `config/sync/core.entity_form_display.paragraph.card.default.yml` and `config/sync/core.entity_view_display.paragraph.card.default.yml`. [[1]](diffhunk://#diff-4a5e600fe1b527a6a0fa5eaeb592e1a6710820d706814acab049f748bc8bc22cR10) [[2]](diffhunk://#diff-47624e08c4ffd9909c27fc99591d6ac46e3b38b9541001da5823dfaae2143695R10)

### New Configurations:
* Added new configuration for the `mautic_form_embed` paragraph type, including its field `field_form_id` in `config/sync/core.entity_form_display.paragraph.mautic_form_embed.default.yml` and `config/sync/field.field.paragraph.mautic_form_embed.field_form_id.yml`. [[1]](diffhunk://#diff-5630acf73af69dd79134255bfbb7c31fcc7fb6110e182883aeac5ddb8d0695cdR1-R23) [[2]](diffhunk://#diff-1cc11e8d6a65d63c3ffc8a7e137affd81a89f7311af2a1ca4d9869b10917b417R1-R19)
* Created a new preview mode for the `hero_section` paragraph type in `config/sync/core.entity_view_display.paragraph.hero_section.preview.yml`.

### Dependency and Module Updates:
* Removed the `mautic_paragraph` module dependency from `config/sync/core.entity_form_display.paragraph.mautic.default.yml`.
* Added a segment taxonomy mapping in `config/sync/mautic_contacts.settings.yml`.

These changes enhance the flexibility and functionality of the paragraph configurations, streamline the URL references, and introduce new paragraph types and fields.